### PR TITLE
Add commodities live dashboard using Commodities-API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Commodities Live Dashboard
+
+Simple front-end dashboard that fetches data from the Commodities-API endpoints you shared:
+
+- `/symbols`
+- `/latest` (base `USD`, symbols `crude,diesel,naphtha` by default)
+- `/getNews`
+
+## Run locally
+
+```bash
+python3 -m http.server 4173
+```
+
+Then open `http://localhost:4173`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,120 @@
+const ACCESS_KEY = "q38sxllxx9x4tcq01zr6q8b18271lcq9p880dmclzprmi8844pr4s0lkqg10";
+const API_BASE = "https://commodities-api.com/api";
+const DEFAULT_SYMBOLS = ["crude", "diesel", "naphtha"];
+
+const refreshBtn = document.getElementById("refreshBtn");
+const baseCurrencyInput = document.getElementById("baseCurrency");
+const lastUpdated = document.getElementById("lastUpdated");
+const ratesContainer = document.getElementById("rates");
+const newsList = document.getElementById("newsList");
+const symbolsContainer = document.getElementById("symbols");
+const rateCardTemplate = document.getElementById("rateCardTemplate");
+
+async function fetchJson(endpoint, params = {}) {
+  const url = new URL(`${API_BASE}/${endpoint}`);
+  url.searchParams.set("access_key", ACCESS_KEY);
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) url.searchParams.set(key, value);
+  });
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed for ${endpoint}: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+function renderRates(rates = {}) {
+  ratesContainer.replaceChildren();
+
+  Object.entries(rates).forEach(([symbol, value]) => {
+    const card = rateCardTemplate.content.cloneNode(true);
+    card.querySelector(".symbol").textContent = symbol.toUpperCase();
+    card.querySelector(".value").textContent = Number(value).toLocaleString(undefined, {
+      maximumFractionDigits: 6,
+    });
+    ratesContainer.appendChild(card);
+  });
+}
+
+function renderNews(news = []) {
+  newsList.replaceChildren();
+
+  if (!Array.isArray(news) || news.length === 0) {
+    const li = document.createElement("li");
+    li.textContent = "No news returned by API.";
+    newsList.appendChild(li);
+    return;
+  }
+
+  news.slice(0, 8).forEach((item) => {
+    const li = document.createElement("li");
+    const title = item.title || item.headline || "Untitled story";
+    const url = item.url || item.link;
+
+    if (url) {
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.target = "_blank";
+      anchor.rel = "noopener noreferrer";
+      anchor.textContent = title;
+      li.appendChild(anchor);
+    } else {
+      li.textContent = title;
+    }
+
+    newsList.appendChild(li);
+  });
+}
+
+function renderSymbols(symbols = {}) {
+  symbolsContainer.replaceChildren();
+  const sortedKeys = Object.keys(symbols).sort().slice(0, 40);
+
+  sortedKeys.forEach((key) => {
+    const chip = document.createElement("span");
+    chip.className = "symbol-chip";
+    chip.textContent = key;
+    symbolsContainer.appendChild(chip);
+  });
+}
+
+async function loadDashboard() {
+  refreshBtn.disabled = true;
+  refreshBtn.textContent = "Loading...";
+
+  const base = (baseCurrencyInput.value || "USD").trim().toUpperCase();
+
+  try {
+    const [symbolsData, latestData, newsData] = await Promise.all([
+      fetchJson("symbols"),
+      fetchJson("latest", {
+        base,
+        symbols: DEFAULT_SYMBOLS.join(","),
+      }),
+      fetchJson("getNews"),
+    ]);
+
+    renderSymbols(symbolsData.data || symbolsData.symbols || {});
+    renderRates(latestData.data?.rates || latestData.rates || {});
+    renderNews(newsData.data || newsData.news || []);
+    lastUpdated.textContent = `Last updated: ${new Date().toLocaleString()}`;
+  } catch (error) {
+    lastUpdated.textContent = `Error: ${error.message}`;
+  } finally {
+    refreshBtn.disabled = false;
+    refreshBtn.textContent = "Refresh now";
+  }
+}
+
+refreshBtn.addEventListener("click", loadDashboard);
+baseCurrencyInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    loadDashboard();
+  }
+});
+
+loadDashboard();
+setInterval(loadDashboard, 60_000);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Commodities Live Dashboard</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Commodities Live Dashboard</h1>
+        <p>Live rates and latest headlines powered by Commodities-API.</p>
+      </header>
+
+      <section class="panel controls">
+        <div>
+          <label for="baseCurrency">Base currency</label>
+          <input id="baseCurrency" value="USD" maxlength="3" />
+        </div>
+        <button id="refreshBtn">Refresh now</button>
+        <p class="meta" id="lastUpdated">Last updated: never</p>
+      </section>
+
+      <section class="panel">
+        <h2>Live Rates</h2>
+        <div id="rates" class="cards"></div>
+      </section>
+
+      <section class="panel">
+        <h2>Latest News</h2>
+        <ul id="newsList" class="news-list"></ul>
+      </section>
+
+      <section class="panel">
+        <h2>Available Symbols</h2>
+        <div id="symbols" class="symbol-grid"></div>
+      </section>
+    </main>
+
+    <template id="rateCardTemplate">
+      <article class="card">
+        <h3 class="symbol"></h3>
+        <p class="value"></p>
+      </article>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,118 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  background: #f5f7fb;
+  color: #1f2937;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+header h1 {
+  margin-bottom: 0.25rem;
+}
+
+header p {
+  margin-top: 0;
+  color: #4b5563;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 1rem;
+  margin-top: 1rem;
+  box-shadow: 0 2px 8px rgba(17, 24, 39, 0.06);
+}
+
+.controls {
+  display: flex;
+  align-items: end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  text-transform: uppercase;
+}
+
+button {
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.55rem 1rem;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #1d4ed8;
+}
+
+.meta {
+  margin: 0;
+  color: #6b7280;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.card {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #f9fafb;
+}
+
+.card h3 {
+  margin: 0;
+}
+
+.card .value {
+  margin-bottom: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.news-list {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.news-list li + li {
+  margin-top: 0.5rem;
+}
+
+.symbol-grid {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.symbol-chip {
+  background: #eef2ff;
+  color: #3730a3;
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
### Motivation
- Provide a simple static dashboard that shows live commodity rates, latest news, and available symbols using the Commodities-API endpoints you supplied.
- Give operators an easy way to change the base currency and manually refresh data while keeping a short auto-refresh interval for near real-time updates.

### Description
- Added a static UI in `index.html` with sections for Live Rates, Latest News, Available Symbols, and a template for rate cards.
- Implemented client-side integration in `app.js` that calls the Commodities-API endpoints (`symbols`, `latest`, `getNews`) using `fetch`, renders results with `renderRates`, `renderNews`, and `renderSymbols`, and exposes a manual refresh and `Enter`-key trigger plus a 60-second auto-refresh.
- Added styling in `styles.css` for a clean card-based, responsive layout and chips for symbols.
- Added `README.md` with local run instructions (`python3 -m http.server 4173`).

### Testing
- Launched a local static server with `python3 -m http.server 4173` and verified the app served `index.html` successfully.
- Ran a headless browser visual check via Playwright that loaded `http://127.0.0.1:4173` and captured a screenshot, which completed successfully.
- Attempted a direct API request with `curl` to the Commodities-API endpoints from this environment, which was blocked by an HTTP proxy/tunnel returning `403`, so live API verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a26e480f0c8329b397d054fadbcc14)